### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "allenap-unison-confgen"
 authors = ["Gavin Panella <gavin@allenap.me>"]
 version = "0.2.0"
 edition = "2021"
-homepage = "https://github.com/allenap/unison-confgen"
+repository = "https://github.com/allenap/unison-confgen"
 description = "Generate Unison configuration files from a YAML description"
 license-file = "LICENSE"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.